### PR TITLE
Add forgotten return statement. Ouch!

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -146,6 +146,8 @@ class TLDetector(object):
         #print("Invoking self.light_classifier.get_classification()");
         cls_id = self.light_classifier.get_classification(cv_image)
         #print("-> {0}".format(cls_id))
+        
+        return cls_id
 
     def process_traffic_lights(self):
         """Finds closest visible traffic light, if one exists, and determines its


### PR DESCRIPTION
Please try this branch first! `TLDetector.get_light_state` was not returning any value. Terrible that it is such a pain to unit test ROS nodes under controlled circumstances...